### PR TITLE
feat: Fix reveledTiles typo in game.js

### DIFF
--- a/resources/js/game.js
+++ b/resources/js/game.js
@@ -570,8 +570,8 @@ class MainComponent extends Component {
         });
     }
     onAttach() {
-        if (this._config.reveledTiles) {
-            this._config.reveledTiles.forEach(x => this._tiles[x.index].setImage(x.image));
+        if (this._config.revealedTiles) {
+            this._config.revealedTiles.forEach(x => this._tiles[x.index].setImage(x.image));
         }
         if (this._config.message) {
             this.refs.popup.setMessage(this._config.message);


### PR DESCRIPTION
### Description
`game.js` has a typo for reveledTiles. This means that when the candidate sends `revealedTiles` - the config would not load. 

This PR fixes this typo