### PR TITLE
feat: Rename `revealed_at` to `finished_at` in games logic

### DIFF
--- a/app/Livewire/Backstage/GameTable.php
+++ b/app/Livewire/Backstage/GameTable.php
@@ -6,7 +6,7 @@ use App\Models\Game;
 
 class GameTable extends TableComponent
 {
-    public $sortField = 'revealed_at';
+    public $sortField = 'finished_at';
 
     public $extraFilters = 'games-filters';
 
@@ -35,8 +35,8 @@ class GameTable extends TableComponent
             ],
 
             [
-                'title' => 'revealed at',
-                'attribute' => 'revealed_at',
+                'title' => 'finished at',
+                'attribute' => 'finished_at',
                 'sort' => true,
             ],
         ];

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -10,12 +10,12 @@ class Game extends Model
 {
     use HasFactory;
 
-    protected $fillable = ['campaign_id', 'prize_id', 'account', 'revealed_at'];
+    protected $fillable = ['campaign_id', 'prize_id', 'account', 'finished_at'];
 
     protected function casts(): array
     {
         return [
-            'revealed_at' => 'datetime',
+            'finished_at' => 'datetime',
         ];
     }
 
@@ -24,7 +24,7 @@ class Game extends Model
         $query = self::query();
         $campaign = Campaign::find(session('activeCampaign'));
 
-        // When filtering by dates, keep in mind `revealed_at` should be stored in Campaign timezone
+        // When filtering by dates, keep in mind `finished_at` should be stored in Campaign timezone
 
         return $query;
     }

--- a/database/factories/GameFactory.php
+++ b/database/factories/GameFactory.php
@@ -26,7 +26,7 @@ class GameFactory extends Factory
             'campaign_id' => $campaign->id,
             'prize_id' => Prize::where('campaign_id', $campaign->id)->inRandomOrder()->first()->id,
             'account' => $this->faker->userName(),
-            'revealed_at' => now()->subDays(random_int(1, 10)),
+            'finished_at' => now()->subDays(random_int(1, 10)),
         ];
     }
 }

--- a/database/migrations/2022_03_31_070121_create_games_table.php
+++ b/database/migrations/2022_03_31_070121_create_games_table.php
@@ -13,13 +13,10 @@ return new class extends Migration {
         Schema::create('games', function (Blueprint $table) {
             $table->id();
             $table->foreignId('campaign_id');
-            $table->foreignId('prize_id')->nullable(); //id of the won prize
-            $table->string('account'); //username of the user who played the game
-            $table->dateTime('revealed_at')->nullable(); //timestamp in campaign's timezone
-            // when the game has been played - it can be different than created_at
+            $table->foreignId('prize_id')->nullable(); // id of the won prize
+            $table->string('account'); // username of the user who played the game
+            $table->dateTime('finished_at')->nullable(); // timestamp in campaign's timezone (When the game was won or lost)
             $table->timestamps();
-
-            $table->index('id', 'default_index');
         });
     }
 


### PR DESCRIPTION
### Description

Renamed the `revealed_at` field to `finished_at` in the games database table, models, factories, and relevant components. This change better reflects the field's purpose of marking when a game was completed, whether won or lost. Updated sorting, filtering, and casts to align with the new field name.